### PR TITLE
Rename owner rank to headadmins, add icon for free admin plugin notification

### DIFF
--- a/Server/Server-Command Restrictor.lua
+++ b/Server/Server-Command Restrictor.lua
@@ -4,16 +4,16 @@ return function()
 	--// Command indexes to not restrict go into the whitelist table below
 	--// If the value is false, it will use the command's original AdminLevel
 	--// If the value is set to a string it will use that as the new AdminLevel
-	--// Any commands not in the below table will be set as Creators only
+	--// Any commands not in the below table will be set as Creators (Level 900) only
 	--// You should be able to use either the command index or one of the command's "Commands" strings
 
 	local commands = { --// Command string or index
-		Shutdown = "Owners";
-		Invisible = "Owners";
+		Shutdown = "HeadAdmins";
+		Invisible = "HeadAdmins";
 		Respawn = "Admins";
-		Visible = "Owners";
-		Shirt = "Owners";
-		Pants = "Owners";
+		Visible = "HeadAdmins";
+		Shirt = "HeadAdmins";
+		Pants = "HeadAdmins";
 		Kick = "Moderators";
 		Ban = "Admins";
 		View = "Moderators";

--- a/Server/Server-Free Admin.lua
+++ b/Server/Server-Free Admin.lua
@@ -13,10 +13,10 @@ local adminLevel = 100 -- level of admin you want to give everyone; NOTE: Creato
   Admin Levels:
   
   Banned   -1
-  Player    0
+  Player    0     (Non-admins - These players are not considered admins)
   Moderator 100
   Admin     200
-  Owner     300   (Owners are basically SuperAdmins)
+  HeadAdmin 300   (HeadAdmins are basically SuperAdmins)
   Creator   900+  (Anything 4 or higher is considering game creator level and can do absolutely anything including edit settings in-game)
 --]]
 
@@ -36,8 +36,9 @@ return function()
 			--Admin.AddAdmin(v,1,true)
 			Remote.MakeGui(p, "Notification", {
 				Title = "Notification";
-				Message = "You are an administrator. Click to view commands.";
+				Message = "You are a(n)"..Admin.LevelToListName(adminLevel)..". Click to view commands.";
 				Time = 10;
+				Icon = "rbxassetid://7536784790";
 				OnClick = Core.Bytecode("client.Remote.Send('ProcessCommand','"..Settings.Prefix.."cmds')");
 			})
 		end

--- a/Server/Server-GivePrivateServerOwnerAdmin.lua
+++ b/Server/Server-GivePrivateServerOwnerAdmin.lua
@@ -2,7 +2,7 @@
 --// Author: TacoBellSaucePackets
 --// Source: https://devforum.roblox.com/t/adonis-g-api-usage/477194/4
 
---// Owners can do :permadmin, so it's unsafe to to make them owners unless you change the perm levels for those commands or disable SaveAdmins in the settings
+--// HeadAdmins can do :permadmin, so it's unsafe to to make them head admins unless you change the perm levels for those commands or disable SaveAdmins in the settings
 local AdminLevel = 200; --// 100 - Mod, 200 - Admin, 300 - HeadAdmin
 
 return function()


### PR DESCRIPTION
- Change remaining mentions of the owner rank to headadmins following the rename of the rank in adonis v216 in the free admin, vip server admin and the command whitelist plugins
- Adds a suitable icon to the free admin notification plugin