### PR TITLE
Trello block message

### DIFF
--- a/Server/Server-Trello Command Logs.lua
+++ b/Server/Server-Trello Command Logs.lua
@@ -1,5 +1,12 @@
 --// Log commands to Trello
 
+--[[
+	Notice: Trello has blocked Roblox from sending requests. This may mean that your trello boards (and this plugin) may not work.
+	Any data obtained from your trello boards (e.g. admin lists, ban lists) will no longer load in-game.
+
+	- windoesboy9
+--]]
+
 server = nil
 service = nil
 

--- a/Server/Server-Trello Command Logs.lua
+++ b/Server/Server-Trello Command Logs.lua
@@ -1,7 +1,7 @@
 --// Log commands to Trello
 
 --[[
-	Notice: Trello has blocked Roblox from sending requests. This may mean that your trello boards (and this plugin) may not work.
+	Notice: Trello has blocked Roblox from using its services. This means that your trello boards (and this plugin) will not work.
 	Any data obtained from your trello boards (e.g. admin lists, ban lists) will no longer load in-game.
 
 	- windoesboy9


### PR DESCRIPTION
**Trello has blocked all Roblox traffic and Adonis's Trello integration no longer works**

Adds a message to the trello command logs that the plugin wont work anymore